### PR TITLE
Fix SeaORM down migrations by cleaning up missing type

### DIFF
--- a/packages/storage/shield-sea-orm/src/migrations/providers/oauth/m20241211_095111_create_provider_oauth.rs
+++ b/packages/storage/shield-sea-orm/src/migrations/providers/oauth/m20241211_095111_create_provider_oauth.rs
@@ -220,7 +220,11 @@ impl MigrationTrait for Migration {
                     .await?;
 
                 manager
-                    .drop_type(Type::drop().name(OauthProviderPkceCodeChallenge::Table).to_owned())
+                    .drop_type(
+                        Type::drop()
+                            .name(OauthProviderPkceCodeChallenge::Table)
+                            .to_owned(),
+                    )
                     .await?;
             }
         }

--- a/packages/storage/shield-sea-orm/src/migrations/providers/oauth/m20241211_095111_create_provider_oauth.rs
+++ b/packages/storage/shield-sea-orm/src/migrations/providers/oauth/m20241211_095111_create_provider_oauth.rs
@@ -218,6 +218,10 @@ impl MigrationTrait for Migration {
                 manager
                     .drop_type(Type::drop().name(OauthProviderType::Table).to_owned())
                     .await?;
+
+                manager
+                    .drop_type(Type::drop().name(OauthProviderPkceCodeChallenge::Table).to_owned())
+                    .await?;
             }
         }
 

--- a/packages/storage/shield-sea-orm/src/migrations/providers/oidc/m20241211_184751_create_provider_oidc.rs
+++ b/packages/storage/shield-sea-orm/src/migrations/providers/oidc/m20241211_184751_create_provider_oidc.rs
@@ -219,7 +219,11 @@ impl MigrationTrait for Migration {
                     .await?;
 
                 manager
-                    .drop_type(Type::drop().name(OidcProviderPkceCodeChallenge::Table).to_owned())
+                    .drop_type(
+                        Type::drop()
+                            .name(OidcProviderPkceCodeChallenge::Table)
+                            .to_owned(),
+                    )
                     .await?;
             }
         }

--- a/packages/storage/shield-sea-orm/src/migrations/providers/oidc/m20241211_184751_create_provider_oidc.rs
+++ b/packages/storage/shield-sea-orm/src/migrations/providers/oidc/m20241211_184751_create_provider_oidc.rs
@@ -217,6 +217,10 @@ impl MigrationTrait for Migration {
                 manager
                     .drop_type(Type::drop().name(OidcProviderType::Table).to_owned())
                     .await?;
+
+                manager
+                    .drop_type(Type::drop().name(OidcProviderPkceCodeChallenge::Table).to_owned())
+                    .await?;
             }
         }
 

--- a/packages/storage/shield-sea-orm/tests/migration.rs
+++ b/packages/storage/shield-sea-orm/tests/migration.rs
@@ -8,44 +8,51 @@ fn example_path() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../examples/sea-orm")
 }
 
-#[test]
-pub fn mysql() {
-    assert!(Command::new("sea-orm-cli")
-        .arg("migrate")
-        .arg("fresh")
-        .arg("-u")
-        .arg("mysql://shield:shield@localhost:13306/shield")
-        .arg("-d")
-        .arg(example_path())
-        .status()
-        .expect("MySQL migration should succeed.")
-        .success());
-}
+const BACKENDS: &[(&str, &str)] = &[
+    ("mysql", "mysql://shield:shield@localhost:13306/shield"),
+    (
+        "postgresql",
+        "postgres://shield:shield@localhost:15432/shield",
+    ),
+    ("sqlite", "sqlite:///tmp/shield-seaorm.sqlite?mode=rwc"),
+];
 
 #[test]
-pub fn postgresql() {
-    assert!(Command::new("sea-orm-cli")
-        .arg("migrate")
-        .arg("fresh")
-        .arg("-u")
-        .arg("postgres://shield:shield@localhost:15432/shield")
-        .arg("-d")
-        .arg(example_path())
-        .status()
-        .expect("MySQL migration should succeed.")
-        .success());
-}
+pub fn migrations() {
+    for (backend, url) in BACKENDS {
+        assert!(Command::new("sea-orm-cli")
+            .arg("migrate")
+            .arg("fresh")
+            .arg("-u")
+            .arg(url)
+            .arg("-d")
+            .arg(example_path())
+            .status()
+            .unwrap_or_else(|_| panic!("{} initial migrations should succeed.", backend))
+            .success());
 
-#[test]
-pub fn sqlite() {
-    assert!(Command::new("sea-orm-cli")
-        .arg("migrate")
-        .arg("fresh")
-        .arg("-u")
-        .arg("sqlite:///tmp/shield-seaorm.sqlite?mode=rwc")
-        .arg("-d")
-        .arg(example_path())
-        .status()
-        .expect("MySQL migration should succeed.")
-        .success());
+        // Check down migrations
+        assert!(Command::new("sea-orm-cli")
+            .arg("migrate")
+            .arg("refresh")
+            .arg("-u")
+            .arg(url)
+            .arg("-d")
+            .arg(example_path())
+            .status()
+            .unwrap_or_else(|_| panic!("{} down migrations should succeed.", backend))
+            .success());
+
+        // Cleanup
+        assert!(Command::new("sea-orm-cli")
+            .arg("migrate")
+            .arg("reset")
+            .arg("-u")
+            .arg(url)
+            .arg("-d")
+            .arg(example_path())
+            .status()
+            .unwrap_or_else(|_| panic!("{} cleanup should succeed.", backend))
+            .success());
+    }
 }


### PR DESCRIPTION
Fixes #12 

Also improves the test script for SeaORM by adding a 'refresh' step, let me know if you prefer a more verbose method.